### PR TITLE
adding correct wowza Jar file directory

### DIFF
--- a/installation_script.go
+++ b/installation_script.go
@@ -175,8 +175,10 @@ func downloadLatestJarFile(channel string, wowzaDir string) error {
 	if err != nil {
 		return fmt.Errorf("Download json file error: %v", err)
 	}
+
 	// Dowload latest LivepeerWowza JAR file
-	if err := downloadFile(wowzaDir, latestURL); err != nil {
+	jarFilePath := filepath.Join(wowzaDir, "lib/")
+	if err := downloadFile(jarFilePath, latestURL); err != nil {
 		return fmt.Errorf("Download latest .jar file error: %v", err)
 	}
 


### PR DESCRIPTION
There was an error in our original script spec for the install script - the JAR actually has to be in `${wowzaDirectory}/lib`, not just `${wowzaDirectory}`. Quick fix here.
